### PR TITLE
Refactor MIDIFile and MIDITrack

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,199 +1,165 @@
 use std::fs;
 use std::str;
-use crate::message::{ EventStatus, MIDIMessage, MIDIFormat, MetaStatus};
-use crate::util:: read_variable_length;
+use crate::message::{MIDIFormat, EventStatus, MIDIMessage, MetaStatus};
+use crate::util::read_variable_length;
 
-# [derive(Clone)]
-pub struct MIDIMessageIter {
+#[derive(Clone)]
+pub struct MIDIFile {
+    pub format: MIDIFormat,
+    pub division: u16,
+    pub tracks: Vec<MidiTrack>,
+}
+
+#[derive(Clone)]
+pub struct MidiTrack {
+    track_idx: u16,
     data: Vec<u8>,
-    bytes: usize,
+}
+
+pub struct MidiTrackIter<'a> {
+    data: &'a [u8],
 
     byte_offset: usize,
     tick_offset: u32,
 
-    last_status: EventStatus,
-    last_event_len: usize,
     last_status_code: u8,
+    last_event_len: usize,
 }
 
-impl MIDIMessageIter {
-    pub fn from_bytes(data: &[u8], bytes: usize) -> MIDIMessageIter {
-        MIDIMessageIter {
-            data: data.to_vec(),
-            bytes: bytes,
-
+impl MidiTrack {
+    pub fn iter(&self) -> MidiTrackIter {
+        MidiTrackIter {
+            data: &self.data,
             byte_offset: 0,
             tick_offset: 0,
-
-            last_status: EventStatus::Meta,
             last_event_len: 0,
             last_status_code: 0,
         }
     }
 }
 
-impl Iterator for MIDIMessageIter {
+impl MIDIFile {
+    pub fn from_file(path: &str) -> Result<MIDIFile, &'static str> {
+        let data = fs::read(path)
+            .expect(concat!("Can not read file ", stringify!(path)));
+        assert!(&data.starts_with(b"MThd"), "Invalid midi file. MThd expected.");
+        let (format, track_num, division) = Self::parse_mthd(&data[8..14]);
+        let mut midi = MIDIFile {
+            format,
+            division,
+            tracks: Vec::new(),
+        };
+        let mut byte_offset = 14;
+
+        for track_idx in 0..track_num {
+            let mut chunk_len = u32::from_be_bytes(
+                data[byte_offset + 4..byte_offset + 8]
+                    .try_into().expect("Invalid chunk!")
+            );
+            // Skip unknown chunks
+            while !data[byte_offset..].starts_with(b"MTrk") {
+                byte_offset += 8 + chunk_len as usize;
+                chunk_len = u32::from_be_bytes(
+                    data[byte_offset + 4..byte_offset + 8]
+                        .try_into().expect("Invalid chunk!")
+                )
+            }
+            let start = byte_offset + 8;
+            let end = start + chunk_len as usize;
+            byte_offset = end;
+            midi.tracks.push(MidiTrack {
+                track_idx,
+                data: data[start..end].to_vec(),
+            });
+        }
+        Ok(midi)
+    }
+
+    fn parse_mthd(data: &[u8]) -> (MIDIFormat, u16, u16) {
+        let to_u16 = |s: &[u8]|
+            u16::from_be_bytes(s.try_into().expect("Error reading midi file."));
+        let format = match to_u16(&data[0..2]) {
+            0 => MIDIFormat::SingleTrack,
+            1 => MIDIFormat::MultiTrack,
+            2 => MIDIFormat::MultiSong,
+            x => panic!("MIDI format {} is not supported.", x),
+        };
+        (format, to_u16(&data[2..4]), to_u16(&data[4..6]))
+    }
+}
+
+impl<'a> Iterator for MidiTrackIter<'a> {
     type Item = MIDIMessage;
 
-    fn next(&mut self) -> Option<MIDIMessage> {
-        if(self.byte_offset >= self.bytes) { return None };
-
-        let (bytes, value) = read_variable_length(&self.data[self.byte_offset..self.byte_offset+4].try_into().expect("Reading variable length error."));
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.byte_offset >= self.data.len() { return None; }
+        let (bytes, value) = read_variable_length(
+            &self.data[self.byte_offset..self.byte_offset + 4]
+                .try_into()
+                .expect("Reading variable length error.")
+        );
         self.byte_offset += bytes as usize;
         self.tick_offset += value as u32;
-        let this_status = &self.data[self.byte_offset];
 
-        let (event_status, message_data, length_to_offset) = match &this_status {
-            // Running status of MIDI Messages has original length - 1.
+        let this_status: u8 = self.data[self.byte_offset];
+        let start = self.byte_offset;
+        let msg = match this_status {
+            // MIDI Messages and SysEx Messages has determinate length.
+            0xF0 | 0xF7 => {
+                let (bytes, mut event_len) = read_variable_length(
+                    match self.data.get(start + 1..start + 5) {
+                        Some(res) => res.try_into().unwrap(),
+                        None => &[0u8; 4]
+                    }
+                );
+                event_len += bytes as usize + 1;
+                self.byte_offset += event_len;
+                self.last_event_len = event_len;
+                self.last_status_code = this_status;
+                let end_byte = self.data[self.byte_offset - 1];
+                assert_eq!(end_byte, 0xf7_u8);
+                return self.next();
+            }
             0x00..=0x7F => {
-                let mut message = vec![self.last_status_code];
-                message.extend_from_slice(&self.data[self.byte_offset..self.byte_offset+self.last_event_len-1]);
-                (self.last_status, message, self.last_event_len - 1)
-            },
-            // MIDI Messages and SysEx Messages has determinated length.
+                assert_ne!(self.last_status_code, 0xFF, "Last status can't be meta");
+                self.byte_offset += self.last_event_len - 1;
+                MIDIMessage::new_event(
+                    self.tick_offset,
+                    self.last_status_code,
+                    &self.data[start..self.byte_offset],
+                ) // data 部分统一不包含 status code，在 new 函数中统一拼接
+            }
             0x80..=0xFE => {
-                self.last_status_code = *this_status;
-                let (status, event_len) = EventStatus::from_status_code(&self.data[self.byte_offset]);
-                (self.last_status, self.last_event_len) = (status, event_len as usize);
-                (status, Vec::from(&self.data[self.byte_offset..self.byte_offset+(event_len as usize)]), event_len as usize)
-            },
+                self.last_status_code = this_status;
+                let event_len = EventStatus::from_status_code(this_status).1 as usize;
+                self.byte_offset += event_len;
+                self.last_event_len = event_len;
+                MIDIMessage::new_event(
+                    self.tick_offset,
+                    this_status,
+                    &self.data[start + 1..self.byte_offset],
+                )
+            }
             // Meta Messages has variable length.
             0xFF => {
-                let (meta_length_bytes, mut metalen) = read_variable_length(match self.data.get(self.byte_offset+2..self.byte_offset+6)
-                {
-                    Some(result) => result.try_into().unwrap(),
-                    None => &[0u8, 0u8, 0u8, 0u8],
-                });
-                metalen += (meta_length_bytes as usize) + 2;
-                (EventStatus::from_status_code(this_status).0, Vec::from(&self.data[self.byte_offset..self.byte_offset+metalen]), metalen)
-            },
+                let (bytes, mut meta_len) = read_variable_length(
+                    match self.data.get(start + 2..start + 6) {
+                        Some(res) => res.try_into().unwrap(),
+                        None => &[0u8; 4]
+                    }
+                );
+                meta_len += bytes as usize + 2;
+                self.byte_offset += meta_len;
+                MIDIMessage::new_meta(
+                    self.tick_offset,
+                    this_status,
+                    &self.data[start + 1..self.byte_offset],
+                )
+            }
         };
-
-        self.byte_offset += length_to_offset;
-
-        Some(MIDIMessage {
-            time: self.tick_offset,
-            status: event_status,
-            data: message_data,
-        })
+        Some(msg)
     }
 }
-
-pub struct MIDITrackIter {
-    data: Vec<u8>,
-    byte_offset: usize,
-    track_num: u16,
-    cur_track_idx: u16,
-}
-
-impl MIDITrackIter {
-    pub fn from_bytes(data: &[u8], track_num: u16) -> MIDITrackIter {
-        MIDITrackIter {
-            data: data.to_vec(),
-            byte_offset: 14,
-            track_num: track_num,
-            cur_track_idx: 0,
-        }
-    }
-}
-
-impl Iterator for MIDITrackIter {
-    type Item = MIDIMessageIter;
-
-    fn next(&mut self) -> Option<MIDIMessageIter> {
-        if(self.cur_track_idx == self.track_num) { return None };
-
-        let mut chunk_length = u32::from_be_bytes(self.data[self.byte_offset+4..self.byte_offset+8].try_into().expect("Invaild chunk!")) as usize;
-
-        // Skip unknown chunks
-        while !(self.data[self.byte_offset..]).starts_with(b"MTrk") {
-            self.byte_offset += 8 + chunk_length;
-            chunk_length = u32::from_be_bytes(self.data[self.byte_offset+4..self.byte_offset+8].try_into().expect("Invaild chunk!")) as usize;
-        }
-
-        let message_iter = MIDIMessageIter::from_bytes(&self.data[self.byte_offset+8..self.byte_offset+8+chunk_length], chunk_length);
-        
-        // Move track pointer and byte pointer.
-        self.cur_track_idx += 1;
-        self.byte_offset += 8 + chunk_length;
-
-        Some(message_iter)
-    }
-}
-
-pub struct MIDIFileIter {
-    pub format: MIDIFormat,
-    pub track_num: u16,
-    pub division: u16,
-    pub track_iter: MIDITrackIter,
-}
-
-impl MIDIFileIter {
-    pub fn read_midi_file(path: &str) -> Result<Self, &'static str> {
-        let data = fs::read(path)
-            .expect(concat!("Can not read file ", stringify!(path)));
-
-        assert!(&data.starts_with(b"MThd"), "Invaild midi file. MThd expected.");
-
-        // Parse MThd Chunk
-        let (format, track_num, division) = MIDIFile::parse_mthd(&data[8..14]);
-
-        Ok(Self {
-            format: format,
-            track_num: track_num,
-            division: division,
-            track_iter: MIDITrackIter::from_bytes(&data, track_num),
-        })
-    }
-}
-
-#[derive(Clone)]
-pub struct MIDITrack {
-    pub message: Vec<MIDIMessage>,
-}
-
-#[derive(Clone)]
-pub struct MIDIFile {
-    pub format: MIDIFormat,
-    pub track_num: u16,
-    pub division: u16,
-    pub track: Vec<MIDITrack>,
-}
-
-impl MIDIFile {
-    pub fn parse_mthd(data: &[u8]) -> (MIDIFormat, u16, u16) {
-        (match u16::from_be_bytes(data[0..2].try_into().expect("Error reading midi file.")) {
-                0 => MIDIFormat::SingleTrack,
-                1 => MIDIFormat::MultiTrack,
-                2 => MIDIFormat::MultiSong,
-                _ => panic!("Not a supported MIDI format."),
-            },
-            u16::from_be_bytes(data[2..4].try_into().expect("Error reading midi file.")),
-            u16::from_be_bytes(data[4..6].try_into().expect("Error reading midi file.")),
-        )
-    }
-
-    pub fn read_midi_file(path: &str) -> Result<Self, &'static str> {
-        let data = fs::read(path)
-            .expect(concat!("Can not read file ", stringify!(path)));
-
-        assert!(&data.starts_with(b"MThd"), "Invaild midi file. MThd expected.");
-
-        // Parse MThd Chunk
-        let (format, track_num, division) = Self::parse_mthd(&data[8..14]);
-
-        Ok(MIDIFile {
-            format,
-            track_num,
-            division,
-            track: MIDITrackIter::from_bytes(&data, track_num)
-                .map(|track| MIDITrack { message: track.into_iter().collect() })
-                .collect(),
-        })
-    }
-
-}
-
 
 #[cfg(test)]
 mod tests {
@@ -201,25 +167,23 @@ mod tests {
 
     #[test]
     fn test_read_midi_head() {
-        let mf = MIDIFile::read_midi_file("tests/tiny.mid").expect("Read midi failed.");
-
+        let mf = MIDIFile::from_file("tests/tiny.mid").expect("Read midi failed.");
         assert!(mf.format == MIDIFormat::MultiTrack);
-        println!("{:?}", mf.track_num);
+        println!("{:?}", mf.tracks.len());
         println!("{:?}", mf.division);
-        for t in mf.track {
-            for m in t.message {
-                if m.status == EventStatus::NoteOn {
-                    println!("{:?}: {:?}", m.time, m.data);
-                }
-                if m.status == EventStatus::Meta {
-                    if m.meta_type().unwrap() == MetaStatus::SetTempo {
-                        println!("tempo {:?}", m.tempo_change().unwrap());
+        for t in mf.tracks {
+            for m in t.iter() {
+                match m {
+                    MIDIMessage::Event(event) => {
+                        println!("{:?}: {:?}", event.time, event.data);
+                    }
+                    MIDIMessage::Meta(meta) => {
+                        if meta.status == MetaStatus::SetTempo {
+                            println!("tempo {:?}", meta.tempo().unwrap());
+                        }
                     }
                 }
             }
         }
-        // assert!(mf.track_num == 18);
-        // assert!(mf.tick_per_quarter == 960);
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@ mod util;
 mod sequence;
 
 use pyo3::prelude::*;
-pub use crate::io::{ MIDIFile };
-pub use crate::message::{ EventStatus, MIDIMessage, MIDIFormat, MetaStatus };
-pub use crate::util::{ read_variable_length };
+pub use crate::io::{MIDIFile};
+pub use crate::message::{EventStatus, MIDIMessage, MIDIFormat, MetaStatus};
+pub use crate::util::{read_variable_length};
 pub use crate::sequence::*;
 
 /// Formats the sum of two numbers as string.

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,206 +1,208 @@
-use crate::message::{ EventStatus, MetaStatus };
-use crate::io::MIDIFile;
 use std::collections::HashMap;
+use crate::io::MIDIFile;
+use crate::message::{MIDIMessage, MetaStatus, EventStatus};
+use crate::util::tempo2qpm;
 
-const DEFAULT_QPM :f32 = 120.0;
+const DEFAULT_QPM: f32 = 120.0;
 const DEFAULT_TEMPO: u32 = 500000;
-
-
-#[derive(Clone, Debug)]
-pub struct Note {
-	pub pitch: u8,
-	pub start: f32,
-	pub duration: f32,
-	pub velocity: u8,
-}
-
-#[derive(Clone, Debug)]
-pub struct ControlChange {
-	pub time: f32,
-	pub value: u8,
-}
-
-#[derive(Clone, Debug)]
-pub struct TimeSignature{
-	pub time: f32,
-	pub numerator: u8,
-	pub denominator: u8,
-}
-
-#[derive(Clone, Debug)]
-pub struct KeySignature{
-	pub time: f32,
-	pub key: i8,
-}
-
-#[derive(Clone, Debug)]
-pub struct Tempo{
-	pub time: f32,
-	pub qpm: f32,
-}
-
-#[derive(Clone, Debug)]
-pub struct Track {
-	pub name: String,
-	pub program: u8,
-	pub is_drum: bool,
-	pub notes: Vec<Note>,
-	pub controls: HashMap<u8, Vec<ControlChange>>,
-}
 
 #[derive(Clone, Debug)]
 pub struct Sequence {
-	pub tracks: Vec<Track>,
-	pub time_signatures: Vec<TimeSignature>,
-	pub key_signatures: Vec<KeySignature>,
-	pub qpm: Vec<Tempo>,
+    pub tracks: Vec<Track>,
+    pub time_signatures: Vec<TimeSignature>,
+    pub key_signatures: Vec<KeySignature>,
+    pub qpm: Vec<Tempo>,
 }
 
-
-#[inline(always)]
-pub fn tempo2qpm(tempo: u32) -> f32 {
-	6e7 / tempo as f32
+#[derive(Clone, Debug, Default)]
+pub struct Track {
+    pub name: String,
+    pub program: u8,
+    pub is_drum: bool,
+    pub notes: Vec<Note>,
+    pub controls: HashMap<u8, Vec<ControlChange>>,
 }
 
-impl Sequence{
-	pub fn from_midi(midi: &MIDIFile) -> Sequence{
-		if (midi.division >> 15) == 1 {panic!()}
-		let tpq = midi.division as f32;
-		let mut qpm = Vec::new();
-		let mut time_signatures = Vec::new();
-		let mut key_signatures = Vec::new();
-		let mut tracks = HashMap::<(u8, u8), Track>::new(); // (track_idx, channel) -> Track
-		let mut track_names = vec![String::new(); midi.track.len()];
-
-		for (track_idx, track) in midi.track.iter().enumerate() {
-			let track_idx = track_idx as u8;
-			let mut cur_instr = [0_u8; 16];
-			let mut last_note_on = [[(0_u32, 0_u8); 128]; 16];
-			for msg in track.message.iter(){
-				match msg.status {
-					EventStatus::Meta => {
-						match msg.meta_type().unwrap() {
-							MetaStatus::SetTempo => {
-								qpm.push(Tempo{
-									time: msg.time as f32 / tpq,
-									qpm: tempo2qpm(msg.tempo_change().unwrap_or(DEFAULT_TEMPO))
-								});
-							},
-							MetaStatus::TimeSignature => {
-								let t = msg.time_signature().unwrap_or((4, 4, 0, 0));
-								time_signatures.push(TimeSignature{
-									time: msg.time as f32 / tpq,
-									numerator: t.0,
-									denominator: t.1
-								});
-							},
-							MetaStatus::KeySignature => {
-									key_signatures.push(KeySignature{
-									time: msg.time as f32 / tpq,
-									key: 0 // TODO
-								});
-							},
-							MetaStatus::TrackName => {
-								let name: String = String::from_utf8(
-									msg.meta_value()
-									.unwrap_or(Vec::new())
-								).unwrap_or(String::new());
-								track_names[track_idx as usize] = name;
-							},
-							_ => {}
-						}
-					},
-					EventStatus::ProgramChange => {
-						cur_instr[msg.channel().unwrap_or(0) as usize] 
-							= msg.program().unwrap_or(0);
-					},
-					EventStatus::ControlChange => {
-						let channel = msg.channel().unwrap_or(0);
-						let track_entry = tracks
-							.entry((track_idx, channel))
-							.or_insert(Track{
-								name: String::new(),
-								program: cur_instr[channel as usize],
-								is_drum: channel == 9,
-								notes: Vec::new(),
-								controls: HashMap::new()
-							});
-						let entry = track_entry
-							.controls.entry(msg.controller_change().unwrap())
-							.or_insert(Vec::new());
-						entry.push(ControlChange{
-							time: msg.time as f32 / tpq,
-							value: msg.controller_change_value().unwrap()
-						})
-					}
-					EventStatus::NoteOn | EventStatus::NoteOff => {
-						let velocity = msg.velocity().unwrap_or(0);
-						let channel = msg.channel().unwrap_or(0);
-						let pitch = msg.key().unwrap();
-						if velocity == 0 || msg.status == EventStatus::NoteOff {
-							// note off
-							let (start, vel) = last_note_on[channel as usize][pitch as usize];
-							if vel != 0 {
-								let entry = tracks.entry((track_idx, channel))
-									.or_insert(Track{
-										name: String::new(),
-										program: cur_instr[channel as usize],
-										is_drum: channel == 9,
-										notes: Vec::new(),
-										controls: HashMap::new()
-									});
-								entry.notes.push(Note{
-									pitch,
-									start: start as f32 / tpq,
-									duration: (msg.time - start) as f32 / tpq,
-									velocity: vel
-								});
-								last_note_on[channel as usize][pitch as usize].1 = 0;
-							} 
-						} else {	// Note on
-							last_note_on[channel as usize][pitch as usize] = (
-								msg.time, velocity
-							);
-						}
-					},
-					_ => {}
-				}
-			}
-		}
-		qpm.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
-		time_signatures.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
-		key_signatures.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
-		if qpm.is_empty() || qpm[0].time > 0.0 {
-			qpm.insert(0, Tempo {time:0.0, qpm: DEFAULT_QPM});
-		}
-		Sequence{
-			tracks: tracks
-				.into_iter()
-				.map(|(k, mut t)| {
-					t.name = track_names[k.0 as usize].clone(); t
-				}).filter(|t| !t.notes.is_empty())
-				.collect(),
-			time_signatures,
-			key_signatures,
-			qpm
-		}
-	}
+#[derive(Copy, Clone, Debug)]
+pub struct Note {
+    pub pitch: u8,
+    pub start: f32,
+    pub duration: f32,
+    pub velocity: u8,
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct ControlChange {
+    pub time: f32,
+    pub value: u8,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct TimeSignature {
+    pub time: f32,
+    pub numerator: u8,
+    pub denominator: u8,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct KeySignature {
+    pub time: f32,
+    pub key: &'static str,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Tempo {
+    pub time: f32,
+    pub qpm: f32,
+}
+
+impl Sequence {
+    pub fn from_file(path: &str) -> Result<Sequence, &'static str> {
+        let midi = MIDIFile::from_file(path)?;
+        Self::from_midi(&midi)
+    }
+    pub fn from_midi(midi: &MIDIFile) -> Result<Sequence, &'static str> {
+        if midi.division >> 15 == 1 {
+            return Err("Division with 1 at high bit is not supported!");
+        }
+        let tpq = midi.division as f32; // ticks per quarter
+        let mut qpm = Vec::new();
+        let mut time_signatures = Vec::new();
+        let mut key_signatures = Vec::new();
+        let mut tracks = HashMap::<(u8, u8), Track>::new();
+        let mut track_names = vec![String::new(); midi.tracks.len()];
+        for (track_idx, track) in midi.tracks.iter().enumerate() {
+            let mut cur_instr = [0_u8; 16]; // 16 channels
+            let mut last_note_on = [[(0_u32, 0_u8); 128]; 16]; // （start, velocity)
+            for msg in track.iter() {
+                match msg {
+                    MIDIMessage::Event(event) => {
+                        let cur = event.time as f32 / tpq;
+                        match event.status {
+                            EventStatus::ProgramChange => {
+                                cur_instr[event.channel().unwrap_or(0) as usize]
+                                    = event.program().unwrap_or(0)
+                            }
+                            EventStatus::ControlChange => {
+                                let channel = event.channel().unwrap_or(0);
+                                let track_entry = tracks
+                                    .entry((track_idx as u8, channel))
+                                    .or_insert(Track {
+                                        program: cur_instr[channel as usize],
+                                        is_drum: channel == 9,
+                                        ..Track::default()
+                                    });
+                                let (ctrl_k, ctrl_v) = event.control_change().unwrap();
+                                let ctrl_entry = track_entry
+                                    .controls.entry(ctrl_k)
+                                    .or_insert(Vec::new());
+                                ctrl_entry.push(ControlChange {
+                                    time: cur,
+                                    value: ctrl_v,
+                                });
+                            }
+                            EventStatus::NoteOn | EventStatus::NoteOff => {
+                                let velocity = event.velocity().unwrap_or(0);
+                                let channel = event.channel().unwrap_or(0);
+                                let pitch = event.key().unwrap();
+                                // NoteOff
+                                if velocity == 0 || event.status == EventStatus::NoteOff {
+                                    let (start, on_vel) = last_note_on[channel as usize][pitch as usize];
+                                    if on_vel != 0 {
+                                        let track_entry = tracks
+                                            .entry((track_idx as u8, channel))
+                                            .or_insert(Track {
+                                                program: cur_instr[channel as usize],
+                                                is_drum: channel == 9,
+                                                ..Track::default()
+                                            });
+                                        track_entry.notes.push(Note {
+                                            pitch,
+                                            velocity: on_vel,
+                                            start: start as f32 / tpq,
+                                            duration: (event.time - start) as f32 / tpq,
+                                        });
+                                        last_note_on[channel as usize][pitch as usize].1 = 0;
+                                    }
+                                } else {
+                                    last_note_on[channel as usize][pitch as usize] = (event.time, velocity);
+                                }
+                            }
+                            _ => {} // Pass unused event
+                        }
+                    }
+                    MIDIMessage::Meta(meta) => {
+                        let cur = meta.time as f32 / tpq;
+                        match meta.status {
+                            MetaStatus::SetTempo => {
+                                qpm.push(Tempo {
+                                    time: cur,
+                                    qpm: tempo2qpm(meta.tempo().unwrap_or(DEFAULT_TEMPO)),
+                                })
+                            }
+                            MetaStatus::TimeSignature => {
+                                let t = meta.time_signature().unwrap_or((4, 4, 0, 0));
+                                time_signatures.push(TimeSignature {
+                                    time: cur,
+                                    numerator: t.0,
+                                    denominator: t.1,
+                                })
+                            }
+                            MetaStatus::KeySignature => {
+                                key_signatures.push(KeySignature {
+                                    time: cur,
+                                    key: meta.key_signature().unwrap(),
+                                })
+                            }
+                            MetaStatus::TrackName => {
+                                let name: String = String::from_utf8(
+                                    meta.meta_value().to_vec()
+                                ).unwrap();
+                                track_names[track_idx] = name;
+                            }
+                            _ => {} // Pass unknown meta
+                        }
+                    }
+                }
+            }
+        }
+
+        qpm.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
+        time_signatures.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
+        key_signatures.sort_by(|a, b| a.time.partial_cmp(&b.time).unwrap());
+        if qpm.is_empty() || qpm[0].time > 0.0 {
+            qpm.insert(0, Tempo { time: 0.0, qpm: DEFAULT_QPM });
+        }
+        println!("Track Num: {}", tracks.len());
+        Ok(Sequence {
+            tracks: tracks
+                .into_iter()
+                .map(|(k, mut t)| {
+                    t.name = track_names[k.0 as usize].clone();
+                    t
+                }) // .filter(|t| !t.notes.is_empty())
+                .collect(),
+            time_signatures,
+            key_signatures,
+            qpm,
+        })
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_midi2seq() {
-		let mf = MIDIFile::read_midi_file("tests/tiny.mid").expect("Read midi failed.");
-		let seq = Sequence::from_midi(&mf);
-		println!("Time Signature: {:?}", seq.time_signatures);
-		println!("Key Signature: {:?}", seq.key_signatures);
-		println!("QPM {:?}", seq.qpm);
-		for track in  seq.tracks {
-			println!("Track: {}", track.name);
-			println!("{:?}", track);
-		}
-	}
+    #[test]
+    fn test_midi2seq() {
+        let seq = Sequence::from_file("tests/tiny.mid").unwrap();
+        println!("Time Signature: {:?}", seq.time_signatures);
+        println!("Key Signature: {:?}", seq.key_signatures);
+        println!("QPM {:?}", seq.qpm);
+        for track in seq.tracks {
+            println!("Track: {}", track.name);
+            println!("{:?}", track);
+        }
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,27 +1,32 @@
-pub fn read_variable_length(data: &[u8;4]) -> (u8, usize) {
-	let mut bytes: u8 = 0;
-	let mut value: usize = 0;
+pub fn read_variable_length(data: &[u8; 4]) -> (u8, usize) {
+    let mut bytes: u8 = 0;
+    let mut value: usize = 0;
 
-	for (i, &n) in data.iter().enumerate() {
-		value = (value << 7) + (n & 0x7f) as usize;
-		if n & 0x80 != 0x80 {
-			bytes = (i + 1) as u8;
-			break;
-		}
-	}
+    for (i, &n) in data.iter().enumerate() {
+        value = (value << 7) + (n & 0x7f) as usize;
+        if n & 0x80 != 0x80 {
+            bytes = (i + 1) as u8;
+            break;
+        }
+    }
 
-	(bytes, value)
+    (bytes, value)
+}
+
+#[inline(always)]
+pub fn tempo2qpm(tempo: u32) -> f32 {
+    6e7 / tempo as f32
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn test_read_vlq() {
-		assert!(read_variable_length(&([0x40u8, 0x00u8, 0x00u8, 0x00u8])).1 == 0x40usize);
-		assert!(read_variable_length(&([0xC0u8, 0x00u8, 0x00u8, 0x00u8])).1 == 0x2000usize);
-		assert!(read_variable_length(&([0x81u8, 0x80u8, 0x00u8, 0x00u8])).1 == 0x4000usize);
-		assert!(read_variable_length(&([0xFFu8, 0xFFu8, 0x7Fu8, 0x00u8])).1 == 0x1FFFFFusize);
-	}
+    #[test]
+    fn test_read_vlq() {
+        assert!(read_variable_length(&([0x40u8, 0x00u8, 0x00u8, 0x00u8])).1 == 0x40usize);
+        assert!(read_variable_length(&([0xC0u8, 0x00u8, 0x00u8, 0x00u8])).1 == 0x2000usize);
+        assert!(read_variable_length(&([0x81u8, 0x80u8, 0x00u8, 0x00u8])).1 == 0x4000usize);
+        assert!(read_variable_length(&([0xFFu8, 0xFFu8, 0x7Fu8, 0x00u8])).1 == 0x1FFFFFusize);
+    }
 }


### PR DESCRIPTION
* Refactor the code so that the MIDITrack::iter function can construct an iterator that returns a MidiMessage on the spot
* Separate events from meta messages, Event uses [u8; 8] to store data, Meta uses Box<[u8]>
* Ignore the SysEx Message to support more midi